### PR TITLE
Fix doc to spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda update conda
-  - conda create -n testenv pip pytest python=$TRAVIS_PYTHON_VERSION numpy h5py coverage event-model doct jinja2 pandas prettytable
+  - conda create -n testenv pip pytest python=$TRAVIS_PYTHON_VERSION databroker numpy h5py coverage event-model doct jinja2 pandas prettytable ophyd
   - source activate testenv
   - if [[ $TRAVIS_PYTHON_VERSION != "2.7" ]]; then
       conda install databroker bluesky -c lightsource2-tag;

--- a/suitcase/spec.py
+++ b/suitcase/spec.py
@@ -1195,6 +1195,7 @@ class DocumentToSpec(CallbackBase):
         self._has_not_written_scan_header = True
         self._num_events_received = 0
         self._num_baseline_events_received = 0
+        super().__init__()
 
     def start(self, doc):
         """


### PR DESCRIPTION
We need to fix document to spec.
We inherit from `CallBackBase` but never call super!

We need to inherit the new `resource` and `datum` methods
