### PR TITLE
Name package 'suitcase-core' and defend against conflict with 'suitcase'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,24 @@ from setuptools import setup
 import sys
 
 
+class IncompatiblePackageError(Exception):
+    pass
+
+# Make sure that the unrelated package by the name 'suitcase' is *not*
+# installed because if it is installed it will break this suitcase's namespace
+# package scheme.
+try:
+    import suitcase
+except ImportError:
+    pass
+else:
+    if hasattr(suitcase, '__file__'):
+        raise IncompatiblePackageError(
+            "The package 'suitcase' must be uninstalled before "
+            "'suitcase-core' can be installed. The package distributed under "
+            "the name 'suitcase' is an unrelated project, and it creates "
+            "conflicts with suitcase-core's namespace packages.")
+
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
@@ -33,7 +51,7 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
 
 
 setup(
-    name='suitcase',
+    name='suitcase-core',
     version='0.8.0',
     description="Exporters / serializers for bluesky documents.",
     long_description=readme,


### PR DESCRIPTION
I put some code at the top of ``setup.py`` to prevent people from installing
suitcase-core on top of suitcase (which would otherwise lead to a "successful"
but broken installation).

Here I install the "other" suitcase that is not ours first:

```
10:41 $ pip install suitcase
Collecting suitcase
Requirement already satisfied: six in ./venv/bnl/lib/python3.6/site-packages (from suitcase)
Installing collected packages: suitcase
Successfully installed suitcase-0.10.2
```

And now I try to install suitcase-core. I get a nice error message.
(This is equivalent to `pip install suitcase-core` once we publish the package.)

```
(bnl) ✔ ~ 
10:41 $ pip install Repos/bnl/suitcase
Processing ./Repos/bnl/suitcase
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-dwpf_e2e-build/setup.py", line 19, in <module>
        "The package 'suitcase' must be uninstalled before "
    __main__.IncompatiblePackageError: The package 'suitcase' must be uninstalled before 'suitcase-core' can be installed. The package distributed under the name 'suitcase' is an unrelated project, and it creates conflicts with suitcase-core's namespace packages.
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-dwpf_e2e-build/
```

Now if I take that advice and uninstall 'suitcase'...

```
(bnl) ✘-1 ~ 
10:41 $ pip uninstall suitcase
Uninstalling suitcase-0.10.2:
Proceed (y/n)? y

<snipped...>

  Successfully uninstalled suitcase-0.10.2
```

I can then succesfully install and use suitcase and its namespace subpackages.

```
(bnl) ✔ ~ 
10:41 $ pip install Repos/bnl/suitcase
Processing ./Repos/bnl/suitcase
Requirement already satisfied: suitcase-utils in ./Repos/bnl/suitcase-utils (from suitcase-core==0.8.0)
Installing collected packages: suitcase-core
  Running setup.py install for suitcase-core ... done
Successfully installed suitcase-core-0.8.0
```